### PR TITLE
Vehicle tab refinements + live-streaming, searchable Logs tab

### DIFF
--- a/frontend/server.py
+++ b/frontend/server.py
@@ -7,12 +7,18 @@ import os
 import json
 import logging
 import threading
+import time
 
 from flask import Flask, jsonify, render_template, request, Response, redirect, url_for
 
 from frontend import data
 from frontend.live import live
 from lib.helpers import publish_message
+from lib.log_buffer import install as _install_log_buffer
+
+# Attach the Logs tab's ring-buffer handler as early as possible (module import time) so it
+# captures startup log lines too, not just what's logged after the first /api/logs request.
+_install_log_buffer()
 
 app = Flask(__name__, static_folder="static", template_folder="templates")
 # Don't let browsers cache the dashboard's JS/CSS — it's edited often and served
@@ -279,6 +285,22 @@ def api_control_ev_charge():
         return jsonify({"ok": False, "error": str(e)}), 500
 
 
+@app.route("/api/control/refresh-vehicle", methods=["POST"])
+def api_control_refresh_vehicle():
+    """Manual 'Refresh Data' button (Vehicle tab). Sets a one-shot flag the EV controller
+    consumes on its next tick, forcing an immediate wake + status refresh outside the normal
+    engagement gating — a direct API call from here would race the controller's own state
+    machine, so we drive it through the same intent-flag pattern as Start/Stop."""
+    try:
+        from lib.global_state import GlobalStateClient
+        GlobalStateClient().set("vehicle_refresh_requested", True)
+        logging.info("Manual vehicle data refresh requested.")
+        return jsonify({"ok": True})
+    except Exception as e:
+        logging.warning("Vehicle refresh request failed: %s", e)
+        return jsonify({"ok": False, "error": str(e)}), 500
+
+
 @app.route("/api/advisor", methods=["POST"])
 def api_advisor():
     """Run the read-only AI advisor — a default daily review, or answer an open
@@ -348,6 +370,55 @@ def api_advisor_delete_exchange():
     except OSError as e:
         logging.warning("Advisor exchange delete failed: %s", e)
         return jsonify({"ok": False, "error": f"delete failed: {e}"}), 500
+
+
+@app.route("/api/logs")
+def api_logs():
+    """Recent buffered log lines (oldest first). Captures this process's own log output —
+    when the dashboard runs in-process (FRONTEND_ENABLED=True) that's the whole service;
+    standalone, it's just the dashboard's own (sparse) log activity."""
+    from lib.log_buffer import get_handler
+    items = get_handler().snapshot()
+    return jsonify({"lines": [line for _, line in items]})
+
+
+LOGS_STREAM_MAX_SECONDS = 600  # bound a single SSE connection's lifetime (see gen() below)
+
+
+@app.route("/api/logs/stream")
+def api_logs_stream():
+    """Server-Sent Events: push new log lines as they're emitted.
+
+    Runs on the Flask dev server (thread-per-connection, no reverse proxy in front of it here),
+    which only notices a dropped client on its next write — a client that vanishes without a
+    clean close (phone loses signal mid-tab) can pin a thread for a long time. Rather than
+    tracking liveness directly, cap the connection's own lifetime: EventSource auto-reconnects
+    by default (we never call .close() client-side), so ending the generator periodically just
+    recycles the underlying connection/thread instead of holding either open indefinitely.
+    """
+    from lib.log_buffer import get_handler
+    handler = get_handler()
+
+    def gen():
+        started = time.time()
+        items = handler.snapshot()
+        last_seq = items[-1][0] if items else 0
+        # "snapshot" (full buffer, replaces whatever the client has rendered) vs "append"
+        # (incremental) — every new connection, including the auto-reconnect once
+        # LOGS_STREAM_MAX_SECONDS elapses, starts with a snapshot; the client must not treat
+        # a reconnect's snapshot as more lines to append or the visible log duplicates.
+        yield f"data: {json.dumps({'type': 'snapshot', 'lines': [line for _, line in items]})}\n\n"
+        while time.time() - started < LOGS_STREAM_MAX_SECONDS:
+            new_items = handler.wait_for_more(last_seq, timeout=15)
+            if new_items:
+                last_seq = new_items[-1][0]
+                yield f"data: {json.dumps({'type': 'append', 'lines': [line for _, line in new_items]})}\n\n"
+            else:
+                yield ": keepalive\n\n"
+
+    return Response(gen(), mimetype="text/event-stream",
+                    headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no",
+                             "Connection": "keep-alive"})
 
 
 @app.route("/healthz")

--- a/frontend/static/css/app.css
+++ b/frontend/static/css/app.css
@@ -67,10 +67,19 @@ body {
 .solar-prices b { color: var(--text); font-weight: 600; }
 .solar-prices .plt { color: var(--muted); font-size: 11px; }
 
-.tabs { display: flex; gap: 6px; padding: 10px 16px 0; max-width: 1100px; margin: 0 auto; border-bottom: 1px solid var(--line); }
+/* flex-wrap:nowrap + overflow-x:auto: with 9 tabs this row no longer reliably fits above
+   ~1100px (e.g. tablet widths), so it scrolls horizontally instead of silently clipping the
+   last tab(s) — scrollbar hidden (still scrollable via touch/trackpad/wheel) to match the
+   existing .status-strip pattern on mobile. */
+.tabs {
+  display: flex; flex-wrap: nowrap; gap: 6px; padding: 10px 16px 0; max-width: 1100px;
+  margin: 0 auto; border-bottom: 1px solid var(--line);
+  overflow-x: auto; scrollbar-width: none; -webkit-overflow-scrolling: touch;
+}
+.tabs::-webkit-scrollbar { display: none; }
 .tab {
   background: var(--panel-2); color: var(--muted); border: 1px solid var(--line);
-  border-bottom: none; cursor: pointer; padding: 9px 18px;
+  border-bottom: none; cursor: pointer; padding: 9px 18px; flex: 0 0 auto; white-space: nowrap;
   border-radius: 9px 9px 0 0; font-size: 14px; font-weight: 600; position: relative; top: 1px;
 }
 .tab:hover { color: var(--text); }
@@ -148,6 +157,12 @@ main { padding: 12px 16px 80px; max-width: 1100px; margin: 0 auto; }
 .metrics-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 12px; margin-bottom: 14px; }
 .metric-card { background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 14px; text-align: center; }
 .metric-card .metric-label { color: var(--muted); font-size: 13px; margin-top: 4px; }
+
+/* Vehicle tab cards — smaller footprint than the shared .metrics-grid/.metric default so more
+   fit per row; scoped to #tab-vehicle only (Trends/Overview keep the base sizing). Text size
+   is untouched (.metric .label/.value are unchanged) — only the card's own box shrinks. */
+#tab-vehicle .metrics-grid { grid-template-columns: repeat(auto-fit, minmax(128px, 1fr)); gap: 8px; }
+#tab-vehicle .metric { padding: 8px 10px; }
 .gridbar { display: flex; height: 16px; border-radius: 8px; overflow: hidden; background: var(--line); margin: 4px 0 8px; }
 .gridbar span { display: block; height: 100%; }
 .gridbar-legend { display: flex; gap: 14px; justify-content: center; font-size: 12px; flex-wrap: wrap; }
@@ -284,6 +299,29 @@ main { padding: 12px 16px 80px; max-width: 1100px; margin: 0 auto; }
 .cfg-edit .cancel { background: var(--line); color: var(--text); }
 .cfg-msg { font-size: 12px; margin-left: 8px; }
 .cfg-note { color: var(--muted); font-size: 12px; margin: 0 0 10px; }
+
+.vehicle-card-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap; }
+.vehicle-card-head h3 { flex: 1 1 auto; min-width: 0; }
+.vehicle-card-head .btn-secondary { flex: 0 0 auto; padding: 6px 12px; font-size: 13px; }
+
+/* Logs tab — scrollable, auto-scrolling terminal-style tail */
+.logs-card-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; flex-wrap: wrap; }
+.logs-card-head h3 { flex: 1 1 auto; min-width: 0; }
+.logs-search {
+  flex: 0 0 auto; width: 200px; max-width: 100%;
+  background: var(--panel-2); color: var(--text); border: 1px solid var(--line);
+  border-radius: 6px; padding: 6px 10px; font-size: 13px; font-family: ui-monospace, monospace;
+}
+.logs-search::placeholder { color: var(--muted); }
+.logs-output {
+  height: 65vh; min-height: 260px; overflow-y: auto;
+  background: var(--panel-2); border: 1px solid var(--line); border-radius: 8px;
+  padding: 8px 10px; font-family: ui-monospace, monospace; font-size: 12px; line-height: 1.5;
+  white-space: pre-wrap; word-break: break-word;
+}
+.log-line { border-bottom: 1px solid var(--line); padding: 1px 0; }
+.log-line:last-child { border-bottom: none; }
+.log-hl { background: var(--accent); color: #06121f; border-radius: 2px; padding: 0 1px; }
 
 /* Victron tab — CerboGX-style schedule list */
 .vic-row { display: flex; align-items: center; padding: 15px 6px; border-bottom: 1px solid var(--line); }

--- a/frontend/static/css/app.mobile.css
+++ b/frontend/static/css/app.mobile.css
@@ -190,6 +190,18 @@
     line-height: 1.2;
   }
 
+  /* Vehicle tab: smaller cards, 3 per row instead of 2, without shrinking the label/value
+     text set above (those rules still apply — only the card box/grid gets tighter here). */
+  #tab-vehicle .metrics-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 6px;
+  }
+
+  #tab-vehicle .metric {
+    min-height: 60px;
+    padding: 7px 6px;
+  }
+
   .overview-row {
     grid-template-columns: 1fr;
     gap: 10px;

--- a/frontend/static/js/app.js
+++ b/frontend/static/js/app.js
@@ -92,6 +92,7 @@ function activateTab(tabName) {
   if (tab) tab.classList.add("active");
   panel.classList.add("active");
   syncMobileNavState();
+  if (tabName === "logs") connectLogsStream(); else disconnectLogsStream();
 }
 
 document.querySelectorAll(".tab").forEach((t) => {
@@ -1809,6 +1810,117 @@ async function refreshVehicleUsage() {
   } catch (e) { /* leave the placeholder */ }
 }
 
+// ---- Logs tab: live tail via SSE, connected lazily while the tab is open ----
+let _logsES = null;
+let _logsLines = [];           // raw buffered lines (bounded), independent of what's filtered/shown
+let _logsFilterTerm = "";
+let _logsFilterDebounce = null;
+const LOGS_MAX_RENDERED = 2000;
+
+function _escapeHtml(s) {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+
+// Finds matches against the RAW line (case-insensitive) and escapes each resulting segment
+// independently, THEN wraps matched segments in a highlight span. Escaping only whole,
+// un-split segments of the original text — never a match found by re-scanning already-escaped
+// output — means an entity like "&amp;" can never get a <mark> boundary spliced into the
+// middle of it (a term like "amp" would otherwise match inside "&amp;"'s own escaped form and
+// corrupt the entity, even though nothing here is exploitable as XSS: the <mark> wrapper is a
+// fixed literal and its content is always pre-escaped).
+function _highlightMatches(line, term) {
+  if (!term) return _escapeHtml(line);
+  const lower = line.toLowerCase();
+  const termLower = term.toLowerCase();
+  if (!termLower) return _escapeHtml(line);
+  let out = "";
+  let i = 0;
+  while (i < line.length) {
+    const idx = lower.indexOf(termLower, i);
+    if (idx === -1) {
+      out += _escapeHtml(line.slice(i));
+      break;
+    }
+    out += _escapeHtml(line.slice(i, idx));
+    out += `<mark class="log-hl">${_escapeHtml(line.slice(idx, idx + term.length))}</mark>`;
+    i = idx + term.length;
+  }
+  return out;
+}
+
+function _pushLogLines(lines, replace) {
+  if (replace) _logsLines = [];
+  if (lines && lines.length) _logsLines = _logsLines.concat(lines);
+  if (_logsLines.length > LOGS_MAX_RENDERED) {
+    _logsLines = _logsLines.slice(_logsLines.length - LOGS_MAX_RENDERED);
+  }
+}
+
+function _renderLogsView() {
+  const el = $("#logs-output");
+  if (!el) return;
+  const wasNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+  const term = _logsFilterTerm.trim();
+  const filtered = term
+    ? _logsLines.filter((line) => line.toLowerCase().includes(term.toLowerCase()))
+    : _logsLines;
+  if (!filtered.length) {
+    el.innerHTML = `<span class="muted">${term ? "no matching lines" : "waiting for logs…"}</span>`;
+    return;
+  }
+  const frag = document.createDocumentFragment();
+  filtered.forEach((line) => {
+    const d = document.createElement("div");
+    d.className = "log-line";
+    d.innerHTML = _highlightMatches(line, term);
+    frag.appendChild(d);
+  });
+  el.innerHTML = "";
+  el.appendChild(frag);
+  if (wasNearBottom) el.scrollTop = el.scrollHeight;
+}
+
+function connectLogsStream() {
+  if (_logsES || !window.EventSource) return;
+  const el = $("#logs-output");
+  if (el) el.innerHTML = '<span class="muted">waiting for logs…</span>';
+  try {
+    _logsES = new EventSource("/api/logs/stream");
+  } catch (e) {
+    if (el) el.innerHTML = '<span class="muted">could not open the log stream.</span>';
+    return;
+  }
+  _logsES.onmessage = (e) => {
+    let ev;
+    try { ev = JSON.parse(e.data); } catch (_) { return; }
+    if (!ev.lines) return;
+    // "snapshot" replaces the buffer (sent on every new connection, including the server's
+    // periodic self-recycle — see LOGS_STREAM_MAX_SECONDS server-side); "append" adds
+    // incrementally. Without this distinction a reconnect would duplicate the whole buffer.
+    _pushLogLines(ev.lines, ev.type === "snapshot");
+    _renderLogsView();
+  };
+}
+
+function disconnectLogsStream() {
+  if (_logsES) { _logsES.close(); _logsES = null; }
+}
+
+const logsSearchInput = document.getElementById("logs-search");
+if (logsSearchInput) {
+  logsSearchInput.addEventListener("input", () => {
+    const value = logsSearchInput.value;
+    clearTimeout(_logsFilterDebounce);
+    // Short debounce so re-filtering 2000 lines on every keystroke of a fast typer doesn't
+    // visibly lag; still reads as instant/live filtering to the user.
+    _logsFilterDebounce = setTimeout(() => {
+      _logsFilterTerm = value;
+      _renderLogsView();
+    }, 120);
+  });
+}
+
 async function refreshWeather() {
   try {
     const r = await fetch("/api/weather").then((x) => x.json());
@@ -1839,6 +1951,21 @@ document.querySelectorAll("[data-ev-charge]").forEach((btn) => {
       });
     } catch (e) { /* ignore; controller acts on its next tick */ }
     setTimeout(() => { btn.disabled = false; }, 1500);
+  });
+});
+
+// Manual "Refresh data" (Vehicle tab): one-shot flag that wakes the car on the controller's
+// next tick (up to ~30s), then normal live updates pick up the fresh state — no separate
+// polling needed here.
+document.querySelectorAll("[data-vehicle-refresh]").forEach((btn) => {
+  btn.addEventListener("click", async () => {
+    const original = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = "Refreshing…";
+    try {
+      await fetch("/api/control/refresh-vehicle", { method: "POST" });
+    } catch (e) { /* ignore; controller picks it up on its next tick regardless */ }
+    setTimeout(() => { btn.disabled = false; btn.textContent = original; }, 4000);
   });
 });
 

--- a/frontend/static/js/app.js
+++ b/frontend/static/js/app.js
@@ -67,6 +67,19 @@ let lastCurrentHourKey = null;
 const MOBILE_MQ = window.matchMedia("(max-width: 680px)");
 const isMobileLayout = () => MOBILE_MQ.matches;
 
+// Logs tab state — declared here (not down near the Logs functions below) because
+// activateTab() calls disconnectLogsStream() on EVERY tab switch, including the very first
+// one fired by setAppView(appViewFromHash()) during initial script execution. A `let` further
+// down the file is hoisted but stays in the temporal dead zone until its declaration line
+// actually runs, so referencing it from a call this early threw "Cannot access before
+// initialization" on cold page load (activateTab -> disconnectLogsStream -> _logsES) — this
+// never showed up in dev testing because those runs opened the page with a `#ess` URL hash,
+// which skips the `view === "overview"` branch that calls activateTab("live") on load.
+let _logsES = null;
+let _logsLines = [];
+let _logsFilterTerm = "";
+let _logsFilterDebounce = null;
+
 const liveOn = () => !!(lastLive && lastLive.connected);
 const truthy = (v) => v === true || v === 1 || String(v || "").trim().toLowerCase() === "true" ||
   String(v || "").trim() === "1" || String(v || "").trim().toLowerCase() === "on";
@@ -1811,10 +1824,8 @@ async function refreshVehicleUsage() {
 }
 
 // ---- Logs tab: live tail via SSE, connected lazily while the tab is open ----
-let _logsES = null;
-let _logsLines = [];           // raw buffered lines (bounded), independent of what's filtered/shown
-let _logsFilterTerm = "";
-let _logsFilterDebounce = null;
+// (_logsES/_logsLines/_logsFilterTerm/_logsFilterDebounce are declared near the top of this
+// file, not here — see the comment there for why.)
 const LOGS_MAX_RENDERED = 2000;
 
 function _escapeHtml(s) {

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -46,6 +46,7 @@
       <button class="tab" data-tab="vehicle">Vehicle</button>
       <button class="tab" data-tab="advisor">Advisor</button>
       <button class="tab" data-tab="config">Configuration</button>
+      <button class="tab" data-tab="logs">Logs</button>
     </nav>
 
     <main>
@@ -131,10 +132,17 @@
 
       <section id="tab-vehicle" class="tab-panel">
         <div class="card">
-          <h3 style="margin:2px 0 10px">Vehicle</h3>
+          <div class="vehicle-card-head">
+            <h3 style="margin:2px 0 10px">Vehicle</h3>
+            <button id="vehicle-refresh" type="button" class="btn-secondary" data-vehicle-refresh
+                    title="Force an on-demand status check now (wakes the car and costs API budget in REST polling mode; free in Fleet Telemetry mode)">Refresh data</button>
+          </div>
           <div id="vehicle"><span class="muted">waiting for vehicle status…</span></div>
           <p class="cfg-note">Live status mirrored from the MQTT bus — read-only, no Tesla API cost.
-            The controller only contacts the car when it needs to act (see the Tesla cost controls).</p>
+            The controller only contacts the car when it needs to act (see the Tesla cost controls).
+            <strong>Refresh data</strong> forces an on-demand status check now — in REST polling
+            mode this wakes the car (billable, budget-capped); in Fleet Telemetry mode it just
+            re-reads the already-streamed state (free).</p>
         </div>
         <div class="card">
           <h3 style="margin:2px 0 10px">Charge control</h3>
@@ -179,6 +187,20 @@
 
       <section id="tab-config" class="tab-panel">
         <div id="config"></div>
+      </section>
+
+      <section id="tab-logs" class="tab-panel">
+        <div class="card logs-card">
+          <div class="logs-card-head">
+            <h3 style="margin:2px 0 10px">Logs</h3>
+            <input id="logs-search" type="search" class="logs-search" placeholder="Filter…"
+                   autocomplete="off" spellcheck="false" aria-label="Filter log lines" />
+          </div>
+          <p class="cfg-note">Live tail of this service's own log output (capped buffer, most
+            recent lines). Streams while this tab is open. Filter is case-insensitive and
+            matches update live as new lines arrive.</p>
+          <div id="logs-output" class="logs-output"><span class="muted">waiting for logs…</span></div>
+        </div>
       </section>
     </main>
 
@@ -240,6 +262,7 @@
         <button type="button" data-mobile-tab="victron">Victron Schedule</button>
         <button type="button" data-mobile-tab="vehicle">Vehicle</button>
         <button type="button" data-mobile-tab="config">Configuration</button>
+        <button type="button" data-mobile-tab="logs">Logs</button>
         <button id="mobile-replan" type="button" data-replan>Replan</button>
         <button id="mobile-restart" type="button" data-restart>Restart</button>
         <button id="mobile-override" type="button" data-ai-override>Override</button>

--- a/lib/ev_charge_controller.py
+++ b/lib/ev_charge_controller.py
@@ -48,6 +48,11 @@ def _num(value, default=0.0):
 # that button exists it stays unset, so only PV-surplus charging can engage the car.
 EV_CHARGE_INTENT_KEY = "ev_charge_requested"
 
+# One-shot "Refresh Data" button (Vehicle tab). Setting this to True wakes the car and forces
+# an immediate status refresh outside the normal engagement gating, then main() clears it back
+# to False so it fires exactly once per press rather than on every subsequent tick.
+REFRESH_REQUEST_KEY = "vehicle_refresh_requested"
+
 
 PROPERTY_MAPPING = {
     "charging_watts": "tesla_power",
@@ -149,6 +154,14 @@ class EvCharger:
           * the car is already drawing power locally (measured charger amps) — we may need
             to adjust the rate or stop.
         This is the primary cost-avoidance layer; the tesla_budget guard is the backstop.
+
+        Deliberately does NOT re-check the manual "Refresh Data" flag (REFRESH_REQUEST_KEY)
+        here — main() reads and clears that flag exactly once per tick and ORs the captured
+        value into its own dormancy check. A second independent read here would race that
+        read-then-clear (a fresh request landing between the two reads would see this method
+        return True on a since-cleared flag, while main()'s stale local copy still read False
+        and skipped both the wake and the clear — delaying, not losing, the request by one
+        tick, but needlessly). Single source of truth avoids that.
         """
         if self._intent_on():                 # dedicated EV-charge intent (decoupled from grid-assist)
             return True
@@ -175,9 +188,16 @@ class EvCharger:
             self._intent_off_edge = self._intent_was_on and not intent  # ...or OFF
             self._intent_was_on = intent
 
+            # Manual "Refresh Data" button — one-shot, so consume (clear) it now regardless of
+            # what happens later this tick; a stuck True would otherwise force a wake every tick.
+            refresh_requested = self._refresh_requested()
+            if refresh_requested:
+                self.global_state.set(REFRESH_REQUEST_KEY, False)
+
             # Engage if something wants a charge OR the user just switched intent off (so we can
-            # stop the car). Otherwise stay dormant and make zero Tesla API calls.
-            if not (self._local_engagement_signal() or self._intent_off_edge):
+            # stop the car) OR a refresh was requested. Otherwise stay dormant and make zero
+            # Tesla API calls.
+            if not (self._local_engagement_signal() or self._intent_off_edge or refresh_requested):
                 self._log_status("dormant", self._dormant_reason())
                 self._reschedule(30.0)
                 return
@@ -186,14 +206,20 @@ class EvCharger:
 
             # Decide whether this tick may WAKE the car (the expensive call). Justified by:
             #  * a fresh intent toggle (on OR off) -> check/act now; or
+            #  * a manual refresh request -> check now; or
             #  * ongoing intent / enough PV surplus -> a rate-limited discovery wake.
             # All wakes remain hard-capped by the tesla_budget guard.
             surplus = self._surplus_available()
             force = wake = False
-            if intent_on_edge or self._intent_off_edge:
+            if intent_on_edge or self._intent_off_edge or refresh_requested:
                 force = wake = True
                 if intent_on_edge:
                     logging.info("EvCharger: EV-charge request toggled on — checking vehicle now.")
+                elif refresh_requested:
+                    # Same telemetry-mode distinction as the discovery-wake log below (L1): in
+                    # telemetry mode update_vehicle_status() never actually wakes the car.
+                    what = "refreshing telemetry state" if self._telemetry_on() else "waking vehicle to refresh status"
+                    logging.info(f"EvCharger: manual refresh requested — {what}.")
             elif (intent or surplus) and self._should_discovery_wake():
                 force = wake = True
                 self._last_discovery_wake_ts = time.time()
@@ -253,6 +279,12 @@ class EvCharger:
         intent permanently on). Until a dedicated EV-charge button sets this key it stays off,
         so only PV-surplus charging can engage the car."""
         return is_truthy(self.global_state.get(EV_CHARGE_INTENT_KEY), False)
+
+    def _refresh_requested(self) -> bool:
+        """Manual 'Refresh Data' button (Vehicle tab). One-shot: main() clears this back to
+        False after consuming it, so it forces exactly one wake+refresh per press rather than
+        re-triggering on every subsequent tick."""
+        return is_truthy(self.global_state.get(REFRESH_REQUEST_KEY), False)
 
     def _surplus_available(self) -> bool:
         """Exportable PV surplus exists (sun up, house battery at/above target, >= min amps)."""

--- a/lib/log_buffer.py
+++ b/lib/log_buffer.py
@@ -1,0 +1,68 @@
+"""In-memory ring buffer of recent log records, for the dashboard's Logs tab.
+
+Attaches an extra logging.Handler to the root logger (alongside the existing
+StreamHandler from logging.basicConfig) so recent formatted log lines can be served
+over HTTP/SSE without reading a log file — the container's stdout isn't otherwise
+accessible from inside the process. Installed lazily on first use so importing this
+module has no side effects.
+"""
+import logging
+import threading
+from collections import deque
+
+MAX_LINES = 2000
+
+
+class RingBufferHandler(logging.Handler):
+    """Thread-safe bounded buffer of (seq, formatted line) tuples."""
+
+    def __init__(self, maxlen: int = MAX_LINES):
+        super().__init__()
+        self._buf = deque(maxlen=maxlen)
+        self._cond = threading.Condition()
+        self._seq = 0
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            msg = self.format(record)
+        except Exception:
+            return
+        with self._cond:
+            self._seq += 1
+            self._buf.append((self._seq, msg))
+            self._cond.notify_all()
+
+    def snapshot(self) -> list:
+        """All buffered (seq, line) tuples, oldest first."""
+        with self._cond:
+            return list(self._buf)
+
+    def wait_for_more(self, after_seq: int, timeout: float = 15.0) -> list:
+        """Block until at least one line newer than after_seq exists (or timeout),
+        then return every buffered line newer than after_seq."""
+        with self._cond:
+            self._cond.wait_for(lambda: bool(self._buf) and self._buf[-1][0] > after_seq,
+                                timeout=timeout)
+            return [item for item in self._buf if item[0] > after_seq]
+
+
+_handler = None
+_install_lock = threading.Lock()
+
+
+def install() -> RingBufferHandler:
+    """Idempotent: attaches the handler to the root logger on first call only."""
+    global _handler
+    with _install_lock:
+        if _handler is not None:
+            return _handler
+        handler = RingBufferHandler()
+        handler.setFormatter(logging.Formatter(
+            fmt="%(asctime)s cerbomoticzGx: %(message)s", datefmt="%Y-%m-%d %H:%M:%S"))
+        logging.getLogger().addHandler(handler)
+        _handler = handler
+        return handler
+
+
+def get_handler() -> RingBufferHandler:
+    return _handler or install()

--- a/tests/js/cold_load_smoke.js
+++ b/tests/js/cold_load_smoke.js
@@ -1,0 +1,130 @@
+// Minimal-stub cold-load smoke test for the dashboard's client-side scripts.
+//
+// Executes powerflow.js, charts.js, and app.js in that order (matching
+// frontend/templates/index.html's <script> tag order) inside one shared global
+// scope via Node's `vm` module -- exactly like a real browser loading the page.
+// If any of them throw during synchronous top-level execution (the exact phase
+// that runs before any user interaction, on every page load), this script exits
+// non-zero and prints the error. See tests/test_frontend_js_smoke.py for why
+// this exists.
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const STATIC_JS = path.join(__dirname, "..", "..", "frontend", "static", "js");
+const SCRIPTS = ["powerflow.js", "charts.js", "app.js"];
+
+function makeElementStub(idHint) {
+  const el = {
+    id: idHint && idHint.startsWith("#") ? idHint.slice(1) : "",
+    dataset: {},
+    classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+    style: {},
+    children: [],
+    childNodes: [],
+    attributes: {},
+    addEventListener() {},
+    removeEventListener() {},
+    appendChild(child) { el.childNodes.push(child); return child; },
+    removeChild() {},
+    setAttribute(name, value) { el.attributes[name] = value; },
+    getAttribute(name) { return el.attributes[name] ?? null; },
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    closest: () => null,
+    focus() {},
+    click() {},
+    scrollTo() {},
+    getBoundingClientRect: () => ({ width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 }),
+  };
+  Object.defineProperty(el, "innerHTML", { get() { return ""; }, set() {} });
+  Object.defineProperty(el, "textContent", { get() { return ""; }, set() {} });
+  return el;
+}
+
+function makeDocumentStub() {
+  const body = makeElementStub();
+  // IMPORTANT: selectors must resolve to a real (non-null) stub element, not null. The bug this
+  // test exists to catch (see tests/test_frontend_js_smoke.py) only manifests once a function
+  // like activateTab() gets PAST its "if (!panel) return" existence guard and reaches the line
+  // that touches a not-yet-declared variable -- a null-returning stub would make every such
+  // guard bail out early and silently hide the exact class of bug we're testing for. This
+  // intentionally does NOT verify that index.html actually contains a matching element for
+  // every selector app.js queries (tests/test_90_mobile_ux_static.py's static string checks are
+  // the closer fit for that); it exists purely to run app.js's real control flow far enough to
+  // catch use-before-declare / ordering bugs during synchronous startup.
+  const bySelector = new Map();
+  const stubFor = (key) => {
+    if (!bySelector.has(key)) bySelector.set(key, makeElementStub(key));
+    return bySelector.get(key);
+  };
+  return {
+    body,
+    documentElement: makeElementStub(),
+    querySelector: (sel) => stubFor(sel),
+    querySelectorAll: (sel) => [stubFor(sel + "#1"), stubFor(sel + "#2")],
+    getElementById: (id) => stubFor("#" + id),
+    createElement: () => makeElementStub(),
+    createDocumentFragment: () => makeElementStub(),
+    addEventListener() {},
+    removeEventListener() {},
+  };
+}
+
+function makeWindowStub() {
+  const listeners = {};
+  const win = {
+    matchMedia: () => ({ matches: false, addEventListener() {}, addListener() {} }),
+    addEventListener(name, fn) { (listeners[name] = listeners[name] || []).push(fn); },
+    removeEventListener() {},
+    location: { hash: "", href: "http://localhost/", search: "" },
+    history: { replaceState() {}, pushState() {} },
+    EventSource: class { constructor() {} close() {} },
+    ResizeObserver: class { observe() {} disconnect() {} unobserve() {} },
+    fetch: () => Promise.reject(new Error("fetch stubbed out in cold-load smoke test")),
+    localStorage: { getItem: () => null, setItem() {}, removeItem() {} },
+    setInterval: () => 0,
+    clearInterval() {},
+    setTimeout: () => 0,
+    clearTimeout() {},
+    console,
+  };
+  return win;
+}
+
+function run() {
+  const document = makeDocumentStub();
+  const window = makeWindowStub();
+  const context = {
+    document,
+    window,
+    console,
+    fetch: window.fetch,
+    EventSource: window.EventSource,
+    ResizeObserver: window.ResizeObserver,
+    setInterval: window.setInterval,
+    clearInterval: window.clearInterval,
+    setTimeout: window.setTimeout,
+    clearTimeout: window.clearTimeout,
+    navigator: { userAgent: "node-cold-load-smoke-test" },
+  };
+  window.window = context;   // self-reference, some browser code does window.window
+  context.self = context;
+  vm.createContext(context);
+
+  for (const name of SCRIPTS) {
+    const filePath = path.join(STATIC_JS, name);
+    const source = fs.readFileSync(filePath, "utf8");
+    try {
+      vm.runInContext(source, context, { filename: filePath });
+    } catch (e) {
+      console.error(`COLD-LOAD SMOKE TEST FAILED while executing ${name}:`);
+      console.error(e && e.stack ? e.stack : e);
+      process.exit(1);
+    }
+  }
+  console.log("cold-load smoke test: all scripts executed without throwing.");
+  process.exit(0);
+}
+
+run();

--- a/tests/test_90_mobile_ux_static.py
+++ b/tests/test_90_mobile_ux_static.py
@@ -253,8 +253,14 @@ def test_external_frames_hide_scrollbars_in_desktop_and_mobile():
     assert "--frame-scrollbar-mask: 48px" in css
     assert "width: calc(100% + var(--frame-scrollbar-mask))" in css
     assert "margin-right: calc(-1 * var(--frame-scrollbar-mask))" in css
-    assert "scrollbar-width: none" not in css
-    assert "-ms-overflow-style: none" not in css
+    # The external Battery/Live iframes specifically must use the mask technique above, not
+    # scrollbar-width/-ms-overflow-style (those only affect same-origin content and can't reach
+    # into a cross-origin iframe's own scrollbar). Scoped to the frame rule itself — other,
+    # same-origin elements (e.g. the tabs bar) may legitimately use scrollbar-width elsewhere.
+    frame_rule_start = css.index(".battery-frame, .live-frame")
+    frame_rule = css[frame_rule_start:css.index("}", frame_rule_start)]
+    assert "scrollbar-width: none" not in frame_rule
+    assert "-ms-overflow-style: none" not in frame_rule
     assert ".battery-frame::-webkit-scrollbar" not in css
     assert "--frame-scrollbar-mask: 48px" in mobile_css
     assert "width: calc(var(--mobile-frame-fit) + var(--frame-scrollbar-mask))" in mobile_css

--- a/tests/test_91_frontend_server.py
+++ b/tests/test_91_frontend_server.py
@@ -122,6 +122,41 @@ def test_grid_assist_route_reuses_existing_grid_charge_toggle(monkeypatch):
     assert calls == [("grid", True)]
 
 
+def test_refresh_vehicle_route_sets_one_shot_state_flag(monkeypatch):
+    import lib.global_state as global_state
+
+    calls = []
+
+    class FakeState:
+        def set(self, key, value):
+            calls.append((key, value))
+
+    monkeypatch.setattr(global_state, "GlobalStateClient", FakeState)
+
+    response = server.app.test_client().post("/api/control/refresh-vehicle")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True}
+    assert calls == [("vehicle_refresh_requested", True)]
+
+
+def test_refresh_vehicle_route_reports_failure(monkeypatch):
+    import lib.global_state as global_state
+
+    class FailingState:
+        def set(self, key, value):
+            raise RuntimeError("db locked")
+
+    monkeypatch.setattr(global_state, "GlobalStateClient", FailingState)
+
+    response = server.app.test_client().post("/api/control/refresh-vehicle")
+
+    assert response.status_code == 500
+    body = response.get_json()
+    assert body["ok"] is False
+    assert "db locked" in body["error"]
+
+
 def test_grid_assist_helper_applies_full_load_immediately(monkeypatch):
     import lib.global_state as global_state
 
@@ -279,3 +314,18 @@ def test_advisor_delete_exchange_route_rejects_bad_index(monkeypatch):
     assert response.status_code == 400
     assert response.get_json()["ok"] is False
     assert "message index out of range" in response.get_json()["error"]
+
+
+def test_logs_route_returns_buffered_lines(monkeypatch):
+    import lib.log_buffer as log_buffer
+
+    class FakeHandler:
+        def snapshot(self):
+            return [(1, "line one"), (2, "line two")]
+
+    monkeypatch.setattr(log_buffer, "get_handler", lambda: FakeHandler())
+
+    response = server.app.test_client().get("/api/logs")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"lines": ["line one", "line two"]}

--- a/tests/test_ev_charge_controller.py
+++ b/tests/test_ev_charge_controller.py
@@ -35,8 +35,8 @@ class FakeTesla:
     def set_tesla_charge_amps(self, amps):
         self.calls.append(("amps", amps)); return True
 
-    def update_vehicle_status(self, force=False):
-        pass
+    def update_vehicle_status(self, force=False, allow_wake=False):
+        self.calls.append(("update_vehicle_status", force, allow_wake))
 
 
 class FakeState(dict):
@@ -68,7 +68,13 @@ def _charger(monkeypatch, tesla, state=None, **attrs):
     c._stop_escalated = False
     c.ess_soc = attrs.get("ess_soc", 95)
     c.surplus_amps = attrs.get("surplus_amps", 6)
+    c.surplus_watts = attrs.get("surplus_watts", 0)
     c.charging_amps = attrs.get("charging_amps", 0)
+    # Only exercised by main() (dynamic_load_reservation_adjustment) — most tests call the
+    # smaller helpers directly and never touch these, but main() needs them set.
+    c.load_reservation = attrs.get("load_reservation", 1000)
+    c.load_reservation_is_reduced = False
+    c.load_reservation_reduction_factor = 2
     return c
 
 
@@ -322,3 +328,43 @@ def test_engagement_signal_dormant_when_idle(monkeypatch):
     # The dedicated EV-charge flag flips it on.
     c.global_state.set("ev_charge_requested", "True")
     assert c._local_engagement_signal() is True
+
+
+def test_refresh_requested_reads_dedicated_flag(monkeypatch):
+    tesla = FakeTesla(is_charging=False)
+    c = _charger(monkeypatch, tesla)
+    assert c._refresh_requested() is False
+    c.global_state.set("vehicle_refresh_requested", "True")
+    assert c._refresh_requested() is True
+
+
+def test_refresh_request_forces_wake_and_clears_itself(monkeypatch):
+    # A full main() tick with a pending refresh request, and NO other engagement signal
+    # (no intent, no surplus, not charging) must: stay engaged rather than take the dormant
+    # early-return (proven by update_vehicle_status being reached at all), force a wake+refresh
+    # read, and clear the one-shot flag so it doesn't re-trigger next tick.
+    tesla = FakeTesla(is_charging=False)
+    c = _charger(monkeypatch, tesla, ess_soc=95, surplus_amps=0, charging_amps=0, sun=False)
+    c.global_state.set("vehicle_refresh_requested", "True")
+    monkeypatch.setattr(c, "_reschedule", lambda *a, **k: None)  # no real Timer/thread in tests
+    monkeypatch.setattr(c, "_control_charging", lambda: False)
+
+    c.main()
+
+    assert ("update_vehicle_status", True, True) in tesla.calls
+    assert c.global_state.get("vehicle_refresh_requested") is False
+
+
+def test_refresh_request_does_not_recur_on_next_tick(monkeypatch):
+    # After being consumed, a stale True lingering anywhere must not force a wake every tick.
+    tesla = FakeTesla(is_charging=False)
+    c = _charger(monkeypatch, tesla, ess_soc=95, surplus_amps=0, charging_amps=0, sun=False)
+    monkeypatch.setattr(c, "_reschedule", lambda *a, **k: None)
+    monkeypatch.setattr(c, "_control_charging", lambda: False)
+    c.global_state.set("vehicle_refresh_requested", "True")
+
+    c.main()   # consumes + clears the flag
+    tesla.calls.clear()
+    c.main()   # nothing should re-engage the controller this time
+
+    assert tesla.calls == []

--- a/tests/test_frontend_js_smoke.py
+++ b/tests/test_frontend_js_smoke.py
@@ -1,0 +1,56 @@
+"""Regression test for a real production outage (2026-07-15): a cold page load of the
+dashboard threw `ReferenceError: Cannot access '_logsES' before initialization` and the
+ENTIRE UI stayed stuck on "loading" forever, because activateTab() -- called synchronously
+during page load via setAppView(appViewFromHash()) -- reached disconnectLogsStream(), which
+referenced a `let` variable declared much further down the file. `let`/`const` bindings are
+hoisted but stay in the "temporal dead zone" until their own declaration line executes, so
+referencing one from code that runs earlier throws and aborts the whole script -- silently,
+with no server-side symptom at all (the backend logs looked completely healthy).
+
+This was missed in manual/browser testing during development because every test load used a
+URL with a `#ess` hash fragment (for convenience, to land directly on a specific tab), which
+happens to skip the exact branch (`view === "overview"` -> `activateTab("live")`) that a real,
+bare-URL first visit hits on every single load.
+
+tests/js/cold_load_smoke.js actually EXECUTES frontend/static/js/app.js's (and the two other
+dashboard scripts') real top-level startup code inside a minimal stubbed DOM/window -- not just
+a static read-the-source check -- so it exercises the real declaration-order semantics of the
+language and catches this whole class of bug (any future `let`/`const` declared "too late" for
+a function that can run during the synchronous startup call chain), not just a recurrence of
+this one specific variable. Verified against both the original broken commit and the fix: fails
+with the exact production stack trace on the former, passes cleanly on the latter.
+
+Deliberately scoped: the stub DOM makes every `querySelector`/`getElementById`/`querySelectorAll`
+call resolve to a generic non-null stub element (memoized per selector, with `.id` derived from
+`#id` selectors) rather than a null/empty result OR a faithful parse of the real index.html.
+That's intentional -- a null-returning stub would make every `if (!el) return` existence guard
+bail out before reaching the code we're trying to exercise (this was tried first and silently
+missed the bug entirely). This test does not verify that index.html actually contains a
+matching element for everything app.js queries; tests/test_90_mobile_ux_static.py's static
+string-order assertions are the tool for that. This test's only job is: does the startup code
+run to completion without throwing.
+"""
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SMOKE_SCRIPT = ROOT / "tests" / "js" / "cold_load_smoke.js"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+def test_dashboard_scripts_execute_cleanly_on_cold_load():
+    result = subprocess.run(
+        ["node", str(SMOKE_SCRIPT)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=str(ROOT),
+    )
+    assert result.returncode == 0, (
+        "frontend/static/js/{powerflow,charts,app}.js threw during a simulated cold page "
+        "load (see tests/js/cold_load_smoke.js and this file's module docstring for why this "
+        f"test exists).\n\nstdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+    )

--- a/tests/test_log_buffer.py
+++ b/tests/test_log_buffer.py
@@ -1,0 +1,84 @@
+import logging
+
+from lib.log_buffer import RingBufferHandler, install
+
+
+def _record(msg="hello"):
+    return logging.LogRecord(
+        name="test", level=logging.INFO, pathname=__file__, lineno=1,
+        msg=msg, args=None, exc_info=None,
+    )
+
+
+def test_emit_appends_formatted_line():
+    h = RingBufferHandler(maxlen=10)
+    h.setFormatter(logging.Formatter("%(message)s"))
+
+    h.emit(_record("hello world"))
+
+    items = h.snapshot()
+    assert len(items) == 1
+    assert items[0][1] == "hello world"
+    assert items[0][0] == 1  # first sequence number
+
+
+def test_buffer_is_bounded():
+    h = RingBufferHandler(maxlen=3)
+    h.setFormatter(logging.Formatter("%(message)s"))
+
+    for i in range(5):
+        h.emit(_record(f"line {i}"))
+
+    items = h.snapshot()
+    assert len(items) == 3
+    assert [line for _, line in items] == ["line 2", "line 3", "line 4"]
+
+
+def test_wait_for_more_returns_only_newer_lines():
+    h = RingBufferHandler(maxlen=10)
+    h.setFormatter(logging.Formatter("%(message)s"))
+    h.emit(_record("first"))
+    first_seq = h.snapshot()[-1][0]
+
+    h.emit(_record("second"))
+    h.emit(_record("third"))
+
+    new_items = h.wait_for_more(first_seq, timeout=1)
+    assert [line for _, line in new_items] == ["second", "third"]
+
+
+def test_wait_for_more_times_out_with_no_new_lines():
+    h = RingBufferHandler(maxlen=10)
+    h.setFormatter(logging.Formatter("%(message)s"))
+    h.emit(_record("only"))
+    last_seq = h.snapshot()[-1][0]
+
+    new_items = h.wait_for_more(last_seq, timeout=0.2)
+    assert new_items == []
+
+
+def test_install_is_idempotent_and_attaches_to_root_logger():
+    h1 = install()
+    h2 = install()
+
+    assert h1 is h2
+    assert h1 in logging.getLogger().handlers
+
+
+def test_installed_handler_captures_real_log_calls():
+    # Explicit level on the logger itself, independent of whatever the root logger's ambient
+    # level happens to be in this process (depends on import order across the test session —
+    # lib.constants sets it to INFO in production, but that's not guaranteed in an isolated run).
+    handler = install()
+    before = len(handler.snapshot())
+    logger = logging.getLogger("some.module")
+    old_level = logger.level
+    logger.setLevel(logging.INFO)
+    try:
+        logger.info("distinctive test message 12345")
+    finally:
+        logger.setLevel(old_level)
+
+    items = handler.snapshot()
+    assert len(items) > before
+    assert any("distinctive test message 12345" in line for _, line in items)


### PR DESCRIPTION
## Summary

Stacked on top of #33 (still open) — this PR only contains the incremental dashboard work built after that one, targeting `v2-roadmap-iteration-2` as its base rather than `main` to keep the diff scoped to what's actually new here.

- **Vehicle tab: compact cards.** Scoped `#tab-vehicle` CSS override (not touching the shared `.metric`/`.metrics-grid` classes used by Overview/Trends) fits more cards per row without shrinking text — 2→3 columns on phone, 3→5 on tablet, 5→7 on desktop.
- **"Refresh data" button** (Vehicle tab) — forces an on-demand Tesla status check. `POST /api/control/refresh-vehicle` sets a one-shot GlobalState flag; `EvCharger.main()` consumes it to force an immediate wake+refresh (bypassing normal engagement gating) and clears it so it fires exactly once per press. Button copy correctly distinguishes REST polling mode (wakes the car, billable) from Fleet Telemetry mode (free, just re-reads streamed state).
- **New "Logs" tab** (after Configuration, desktop nav + mobile menu) — live tail of the process's own log output. `lib/log_buffer.py` is a bounded in-memory ring-buffer `logging.Handler` on the root logger; served via `GET /api/logs` (snapshot) and `GET /api/logs/stream` (SSE). Frontend connects/disconnects the stream lazily with tab activation, auto-scrolls only when already near the bottom.
- **Real-time search/filter** on the Logs tab — case-insensitive substring filter as you type (debounced), only matching lines shown, matches highlighted.
- **Fixed along the way:**
  - The tab bar (now 9 tabs) silently overflowed at tablet widths — made it horizontally scrollable instead of clipping.
  - SSE stream had no client-disconnect detection (Flask dev server, thread-per-connection) — capped the Logs stream's lifetime so a dropped/zombie connection self-recycles via EventSource's normal auto-reconnect, and added a snapshot-vs-append protocol distinction so that reconnect doesn't duplicate the whole rendered buffer.
  - Search highlighting originally ran its match regex against already-HTML-escaped text, which could split an entity like `&amp;` if the search term happened to be a substring of an entity name (e.g. searching "amp"). Not exploitable as XSS, but a real display-corruption bug with realistic log content (exception messages, VRM/Tesla API responses echoed into logs). Fixed by matching against the raw line and escaping each resulting segment independently.
  - A narrow, self-healing TOCTOU race between two independent reads of the one-shot refresh flag.

## ⚠️ Critical fix: this branch briefly broke production

An earlier commit on this PR was deployed (image `2026.07.15.10`) and **completely broke the live dashboard** — every page load stuck on "loading" forever. Root cause: `activateTab()` (near the top of `app.js`) calls `disconnectLogsStream()`, which referenced a `let _logsES` variable declared much further down the file, in the new Logs-tab section. `let`/`const` bindings are hoisted but stay in the "temporal dead zone" until their own declaration line runs — and `setAppView(appViewFromHash())`, which runs synchronously at the bottom of the script on every page load, calls `activateTab("live")` for the default view before the script ever reaches that declaration. Result: `ReferenceError: Cannot access '_logsES' before initialization`, thrown during the page's very first synchronous script execution, aborting the whole script with no server-side symptom at all.

This wasn't caught during development because every test load used a `#ess` URL hash (for convenience, to land directly on a tab), which happens to skip the exact `view === "overview"` branch that a genuine bare-URL first visit hits every time.

**Fixed** by moving the Logs-tab state declarations to the top of `app.js`, before anything that could reference them runs. Verified by reproducing the exact production error (and the "stuck on loading" symptom) via a scripted cold load with no URL hash, confirming the fix resolves it on both desktop and mobile, and confirming a full tab-switching sequence afterward throws nothing.

**Added a regression test** (`tests/js/cold_load_smoke.js` + `tests/test_frontend_js_smoke.py`) that actually *executes* the dashboard's real startup JS (`powerflow.js`, `charts.js`, `app.js`, in the same order and shared scope a browser uses) inside a minimal stubbed DOM via Node's `vm` module — not a static text check, a real execution — so it catches this whole bug class (any future variable declared too late for the synchronous startup path), not just a recurrence of this one. Verified the test fails with the exact production stack trace against the broken commit and passes against the fix. A second, independent review agent then audited all three dashboard scripts for any other instance of this pattern and found none.

## Process

Every change here went through: implement → visually verify in a real browser (Selenium against a mock harness that never touches the real MQTT broker) at iPhone-12-Pro/tablet/desktop widths → independent second-agent code review → fix anything actionable. Three separate review passes (two before the outage, one auditing the hotfix) caught and fixed 6 real issues (listed above) before this PR was ready.

## Test plan

- [x] `DEV=1 pytest -q` — 288 passed
- [x] Vehicle tab card layout verified at 390×844 (iPhone 12 Pro), 820×1180 (tablet), 1440×900 (desktop)
- [x] Refresh Data button click → `/api/control/refresh-vehicle` → `EvCharger` picks up and clears the flag (unit-tested; also confirmed the button's disabled/"Refreshing…" state visually)
- [x] Logs tab streams and auto-scrolls; verified snapshot/append reconnect behavior does not duplicate rendered lines (automated Selenium check over a shortened stream-lifetime window)
- [x] Search filtering verified case-insensitive, highlights correct, "no matching lines" empty state, and the entity-splitting fix verified both via direct function testing and a crafted log line containing `&amp;` and a literal `<danger>` tag rendered safely in a real browser
- [x] **Cold-load regression**: reproduced the production outage exactly (bare URL, no hash) both before and after the fix; new automated smoke test (`tests/test_frontend_js_smoke.py`) covers this going forward