### PR TITLE
Persist Tesla Fleet Telemetry streaming-signal count durably

### DIFF
--- a/frontend/data.py
+++ b/frontend/data.py
@@ -633,23 +633,10 @@ def get_plan() -> dict:
 
 def tesla_usage() -> dict:
     """Current billing cycle's Tesla Fleet API spend (counts + € per category + total) for the
-    Vehicle tab, plus an approximate Streaming Signals line from the telemetry bridge counter."""
+    Vehicle tab, including the Streaming Signals line — both durably persisted to the same
+    tesla_budget state file by lib/tesla_budget.usage_snapshot(), so this survives restarts."""
     path = _env().get("TESLA_BUDGET_STATE_PATH") or _tesla_budget.DEFAULT_STATE_PATH
-    snap = _tesla_budget.usage_snapshot(path)
-    # Streaming Signals are pushed by the car (not requests we make), so they live outside the
-    # budget guard. Display them approximately from the bridge's monthly counter; Tesla bills
-    # ~$1 per 150,000 signals, so this is effectively free but worth showing.
-    try:
-        from lib.global_state import GlobalStateClient
-        month = datetime.utcnow().strftime("%Y-%m")
-        state = GlobalStateClient()
-        sig = 0
-        if state.get("tesla_stream_month") == month:
-            sig = int(state.get("tesla_stream_signals") or 0)
-        snap["streaming"] = {"count": sig, "cost": round(sig / 150000.0, 4), "approx": True}
-    except Exception:
-        snap["streaming"] = {"count": 0, "cost": 0.0, "approx": True}
-    return snap
+    return _tesla_budget.usage_snapshot(path)
 
 
 def get_config() -> list:

--- a/lib/tesla_budget.py
+++ b/lib/tesla_budget.py
@@ -23,6 +23,10 @@ from lib.constants import logging
 # Tesla Fleet API unit prices, USD (2026): commands 1000/$1, data 500/$1, wakes 50/$1.
 UNIT_COST_USD = {"command": 0.001, "data": 0.002, "wake": 0.02}
 
+# Fleet Telemetry "Streaming Signals" - pushed by the car, not requests we make, so this is
+# display-only and never gated by the spend guard below. Tesla bills ~$1 per 150,000 signals.
+STREAMING_SIGNAL_COST_USD = 1.0 / 150000
+
 MONTHLY_CREDIT_USD = 10.0          # Tesla's monthly discount
 MONTHLY_SAFETY_CEILING_USD = 9.0   # HARD guard: the billing cycle's spend never exceeds this
 DAILY_SAFETY_CEILING_USD = 2.0     # per-day runaway breaker (a loop can't burn more than this/day)
@@ -36,6 +40,30 @@ DAYS_PER_MONTH = 31                # for the informational worst-case projection
 DEFAULT_DAILY_CAPS = {"command": 300, "data": 150, "wake": 20}
 
 DEFAULT_STATE_PATH = "data/tesla_budget.json"
+
+_FILE_LOCKS = {}
+_FILE_LOCKS_GUARD = threading.Lock()
+
+
+def _lock_for(path: str) -> threading.RLock:
+    """One process-wide RLock per resolved state-file path.
+
+    Multiple writers share this file: TeslaBudget.spend()/refund() (the EV controller's
+    thread) and the module-level seed_month_usage()/bump_signal_count()/seed_signal_count()
+    below (the telemetry bridge's own MQTT thread calls bump_signal_count() every ~20
+    messages when TESLA_TELEMETRY_ENABLED is on, and scripts/tesla_seed_usage.py can run
+    while the service is live). Without a SHARED lock, a read-modify-write from one caller
+    can interleave with another's and silently revert it -- the write itself is atomic
+    (write-to-.tmp then os.replace), so this isn't file corruption, just a lost update. Keyed
+    by path (not a single global lock) so independent TeslaBudget instances in tests
+    (different tmp_path files) never contend with each other or with the real
+    DEFAULT_STATE_PATH.
+    """
+    key = os.path.abspath(path)
+    with _FILE_LOCKS_GUARD:
+        if key not in _FILE_LOCKS:
+            _FILE_LOCKS[key] = threading.RLock()
+        return _FILE_LOCKS[key]
 
 
 def projected_daily_cost_usd(caps: dict) -> float:
@@ -70,7 +98,10 @@ class TeslaBudget:
         self._caps = clamp_caps_to_ceiling(caps or DEFAULT_DAILY_CAPS)
         self._path = state_path or DEFAULT_STATE_PATH
         self._clock = clock or (lambda: datetime.now(timezone.utc))
-        self._lock = threading.RLock()
+        # Shared per-path lock (see _lock_for) -- not a private RLock -- so this instance's
+        # spend()/refund() serialize against the module-level seed_month_usage()/
+        # bump_signal_count()/seed_signal_count() below when they target the same file.
+        self._lock = _lock_for(self._path)
 
     @property
     def caps(self) -> dict:
@@ -180,6 +211,39 @@ class TeslaBudget:
             }
 
 
+def _load_month_state(path: str) -> dict:
+    """Load state and roll month_counts at the UTC month boundary. Shared by the
+    free-function seed/bump helpers below, which don't need TeslaBudget's daily-cap rolling
+    (streaming signals aren't gated/capped, only counted for display)."""
+    try:
+        with open(path) as f:
+            d = json.load(f)
+        if not isinstance(d, dict):
+            d = {}
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        d = {}
+    now = datetime.now(timezone.utc)
+    month = now.strftime("%Y-%m")
+    if d.get("month") != month:
+        d["month"] = month
+        d["month_counts"] = {}
+    d.setdefault("month_counts", {})
+    d.setdefault("date", now.strftime("%Y-%m-%d"))
+    d.setdefault("counts", {})
+    return d
+
+
+def _save_state(path: str, d: dict) -> None:
+    try:
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        tmp = path + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump(d, f)
+        os.replace(tmp, path)
+    except OSError as e:                        # pragma: no cover - disk failure
+        logging.warning("tesla_budget: could not persist state to %s: %s", path, e)
+
+
 def usage_snapshot(state_path=None) -> dict:
     """Read the CURRENT billing cycle's spend counters for DISPLAY (no live guard needed).
     Returns per-category counts + $ and the month-to-date total, so the dashboard can show
@@ -201,9 +265,15 @@ def usage_snapshot(state_path=None) -> dict:
         cost = round(UNIT_COST_USD[c] * n, 4)
         cats[c] = {"count": n, "cost": cost}
         total += cost
+    sig_count = int(counts.get("signals", 0) or 0)
     return {
         "month": month,
         "categories": cats,                      # command/data/wake -> {count, cost}
+        # Streaming Signals: same durable file/month-roll as the categories above, but priced
+        # and totalled separately (kept OUT of total/remaining) since it's never gated by the
+        # spend guard -- see STREAMING_SIGNAL_COST_USD.
+        "streaming": {"count": sig_count, "cost": round(sig_count * STREAMING_SIGNAL_COST_USD, 4),
+                     "approx": True},
         "total": round(total, 4),
         "unit_cost": dict(UNIT_COST_USD),
         "monthly_credit": MONTHLY_CREDIT_USD,
@@ -215,31 +285,50 @@ def usage_snapshot(state_path=None) -> dict:
 
 
 def seed_month_usage(counts: dict, state_path=None) -> dict:
-    """Set the current billing cycle's DISPLAY counters (e.g. to reconcile with the Tesla
-    developer portal, which is the only authoritative source). Daily cap counters are left
-    untouched; the guard then accumulates from this baseline. Returns the new snapshot."""
+    """Set the current billing cycle's DISPLAY counters for the given categories (e.g. to
+    reconcile with the Tesla developer portal, which is the only authoritative source).
+    Daily cap counters are left untouched; the guard then accumulates from this baseline.
+    Only touches keys present in ``counts`` -- e.g. seeding just "wake" leaves "command",
+    "data", and "signals" (see seed_signal_count) exactly as they were. Returns the new
+    snapshot."""
     path = state_path or DEFAULT_STATE_PATH
-    try:
-        with open(path) as f:
-            d = json.load(f)
-        if not isinstance(d, dict):
-            d = {}
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
-        d = {}
-    now = datetime.now(timezone.utc)
-    d["month"] = now.strftime("%Y-%m")
-    d["month_counts"] = {c: max(0, int(counts.get(c, 0) or 0)) for c in UNIT_COST_USD}
-    d.setdefault("date", now.strftime("%Y-%m-%d"))
-    d.setdefault("counts", {})
-    try:
-        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-        tmp = path + ".tmp"
-        with open(tmp, "w") as f:
-            json.dump(d, f)
-        os.replace(tmp, path)
-    except OSError as e:                        # pragma: no cover
-        logging.warning("tesla_budget: could not seed usage to %s: %s", path, e)
-    return usage_snapshot(path)
+    with _lock_for(path):     # serialize against TeslaBudget.spend()/refund() on the same file
+        d = _load_month_state(path)
+        for c, v in counts.items():
+            if c in UNIT_COST_USD:
+                d["month_counts"][c] = max(0, int(v or 0))
+        _save_state(path, d)
+        return usage_snapshot(path)   # read-back inside the same (reentrant) lock -- no
+                                       # window for another writer to sneak in before we return
+
+
+def bump_signal_count(n: int, state_path=None) -> int:
+    """Durably ADD n to this billing cycle's streaming-signal count. Called by the telemetry
+    bridge as signals arrive (from its own MQTT thread); rolls at the UTC month boundary like
+    the other counters. Kept in the SAME file as command/data/wake so a pod restart can't lose
+    the running total the way the old GlobalState-backed tracking did (GlobalState lives in a
+    SQLite file on tmpfs that main.py explicitly recreates -- DROP TABLE IF EXISTS -- on every
+    process start). Returns the new month-to-date signal count."""
+    path = state_path or DEFAULT_STATE_PATH
+    with _lock_for(path):     # serialize against TeslaBudget.spend()/refund() on the same file
+        d = _load_month_state(path)
+        new_total = max(0, int(d["month_counts"].get("signals", 0) or 0) + int(n))
+        d["month_counts"]["signals"] = new_total
+        _save_state(path, d)
+    return new_total
+
+
+def seed_signal_count(count: int, state_path=None) -> int:
+    """SET (not add to) this billing cycle's streaming-signal count -- e.g. to reconcile with
+    the number shown on the Tesla developer portal's Billing & Usage page, the only
+    authoritative source (mirrors seed_month_usage's role for command/data/wake). Returns the
+    new month-to-date signal count."""
+    path = state_path or DEFAULT_STATE_PATH
+    with _lock_for(path):     # serialize against TeslaBudget.spend()/refund() on the same file
+        d = _load_month_state(path)
+        d["month_counts"]["signals"] = max(0, int(count))
+        _save_state(path, d)
+        return d["month_counts"]["signals"]
 
 
 def caps_from_settings(getter=None) -> dict:

--- a/lib/tesla_telemetry_bridge.py
+++ b/lib/tesla_telemetry_bridge.py
@@ -14,7 +14,7 @@ import threading
 
 from lib.constants import logging
 
-_STREAM_FLUSH_EVERY = 20              # batch stream-signal counter writes to GlobalState
+_STREAM_FLUSH_EVERY = 20              # batch stream-signal counter writes to the durable file
 # fleet-telemetry emits non-"V" record types too (connectivity/alerts/errors); those are not
 # billed as vehicle-data SIGNALS, so exclude them from the streaming-signal estimate.
 _NON_SIGNAL_FIELDS = {"connectivity", "alerts", "errors", "status", "V", "v"}
@@ -202,25 +202,21 @@ class TeslaTelemetryBridge:
 
     def _count_stream_signal(self):
         """Approximate Tesla's 'Streaming Signals' billing by counting received telemetry
-        messages (~one signal each). Batched to GlobalState every _STREAM_FLUSH_EVERY messages
-        to avoid write churn; resets at the UTC month boundary. Display-only — streaming isn't
-        something we gate, so it never touches the tesla_budget guard."""
+        messages (~one signal each). Batched to the durable tesla_budget state file every
+        _STREAM_FLUSH_EVERY messages to avoid write churn; rolls at the UTC month boundary.
+        Display-only — streaming isn't something we gate, so it never touches the tesla_budget
+        spend guard's caps, only its persisted month_counts. Durable (same file as
+        command/data/wake) rather than GlobalState, which lives in a SQLite file on tmpfs that
+        main.py explicitly recreates on every process start, so a signal count kept there was
+        silently lost on every restart."""
         self._sig_seen += 1
         if (self._sig_seen - self._sig_flushed) < _STREAM_FLUSH_EVERY:
             return
         try:
-            from datetime import datetime, timezone
-            from lib.global_state import GlobalStateClient
-            state = GlobalStateClient()
-            month = datetime.now(timezone.utc).strftime("%Y-%m")
-            base = 0
-            if state.get("tesla_stream_month") == month:
-                try:
-                    base = int(state.get("tesla_stream_signals") or 0)
-                except (TypeError, ValueError):
-                    base = 0
-            state.set("tesla_stream_month", month)
-            state.set("tesla_stream_signals", base + (self._sig_seen - self._sig_flushed))
+            from lib.config_retrieval import retrieve_setting
+            from lib.tesla_budget import bump_signal_count, DEFAULT_STATE_PATH
+            path = retrieve_setting("TESLA_BUDGET_STATE_PATH") or DEFAULT_STATE_PATH
+            bump_signal_count(self._sig_seen - self._sig_flushed, path)
             self._sig_flushed = self._sig_seen
         except Exception as e:                 # pragma: no cover - counter must never break the loop
             logging.debug("tesla_telemetry_bridge: stream-signal flush failed: %s", e)

--- a/scripts/tesla_seed_usage.py
+++ b/scripts/tesla_seed_usage.py
@@ -6,8 +6,12 @@ counter is a forward-only estimate whose real job is to ENFORCE the hard spend c
 with the portal's current Billing & Usage numbers (e.g. at the start of a billing cycle) so
 the dashboard total matches; the guard then accumulates new calls from that baseline.
 
+Only the categories you pass are touched — e.g. `--signals 1334` alone leaves command/data/wake
+exactly as they were (and vice versa), so you can reconcile one category at a time.
+
 Usage:
     python scripts/tesla_seed_usage.py --commands 13 --data 30 --wakes 2
+    python scripts/tesla_seed_usage.py --signals 1334
 """
 import os
 import sys
@@ -29,18 +33,35 @@ def _env_path():
 def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--commands", type=int, default=0)
-    ap.add_argument("--data", type=int, default=0)
-    ap.add_argument("--wakes", type=int, default=0)
+    ap.add_argument("--commands", type=int, default=None)
+    ap.add_argument("--data", type=int, default=None)
+    ap.add_argument("--wakes", type=int, default=None)
+    ap.add_argument("--signals", type=int, default=None,
+                    help="set (not add to) this cycle's Streaming Signals count")
     ap.add_argument("--dir", default=None, help="budget state file (default: TESLA_BUDGET_STATE_PATH)")
     args = ap.parse_args()
 
     path = args.dir or _env_path()
-    snap = tb.seed_month_usage(
-        {"command": args.commands, "data": args.data, "wake": args.wakes}, path)
+    counts = {}
+    if args.commands is not None:
+        counts["command"] = args.commands
+    if args.data is not None:
+        counts["data"] = args.data
+    if args.wakes is not None:
+        counts["wake"] = args.wakes
+    if counts:
+        tb.seed_month_usage(counts, path)
+    if args.signals is not None:
+        tb.seed_signal_count(args.signals, path)
+    if not counts and args.signals is None:
+        ap.error("nothing to seed — pass at least one of --commands/--data/--wakes/--signals")
+
+    snap = tb.usage_snapshot(path)
     print(f"Seeded {path} for {snap['month']}:")
     for cat, v in snap["categories"].items():
         print(f"  {cat:<8} {v['count']:>5}   €{v['cost']:.3f}")
+    sig = snap["streaming"]
+    print(f"  {'signals':<8} {sig['count']:>5}   €{sig['cost']:.3f}  (~, not billed against the cap)")
     print(f"  total this cycle: €{snap['total']:.2f} of €{snap['monthly_credit']:.0f}")
     return 0
 

--- a/tests/test_frontend_data.py
+++ b/tests/test_frontend_data.py
@@ -380,3 +380,21 @@ def test_day_totals_ignores_trailing_null_counter(tmp_path):
 
     assert t["import_cost"] == 3.00
     assert t["export_reward"] == 4.00
+
+
+def test_tesla_usage_includes_durable_streaming_signals(monkeypatch, tmp_path):
+    # tesla_usage() now just delegates to tesla_budget.usage_snapshot(), which durably persists
+    # Streaming Signals in the same file as command/data/wake -- no more ephemeral GlobalState
+    # fallback that lost the count on every restart.
+    from lib import tesla_budget as tb
+
+    path = str(tmp_path / "budget.json")
+    monkeypatch.setattr(data, "_env", lambda: {"TESLA_BUDGET_STATE_PATH": path})
+    tb.seed_month_usage({"command": 5, "data": 2, "wake": 1}, path)
+    tb.seed_signal_count(1334, path)
+
+    usage = data.tesla_usage()
+
+    assert usage["categories"]["command"]["count"] == 5
+    assert usage["streaming"]["count"] == 1334
+    assert usage["streaming"]["cost"] == round(1334 * tb.STREAMING_SIGNAL_COST_USD, 4)

--- a/tests/test_tesla_budget.py
+++ b/tests/test_tesla_budget.py
@@ -169,3 +169,96 @@ def test_caps_from_settings_defaults_and_overrides():
     got = tb.caps_from_settings({"TESLA_BUDGET_MAX_DATA_PER_DAY": "25"}.get)
     assert got["data"] == 25
     assert got["wake"] == tb.DEFAULT_DAILY_CAPS["wake"]     # unset falls back
+
+
+# --- Streaming Signals: durable (survives restarts), never gated ----------
+
+def test_bump_signal_count_accumulates_and_persists(tmp_path):
+    path = str(tmp_path / "budget.json")
+    assert tb.bump_signal_count(20, path) == 20
+    assert tb.bump_signal_count(5, path) == 25
+    # "Restart" = a fresh read of the same file -- nothing kept in memory to lose.
+    assert tb.usage_snapshot(path)["streaming"]["count"] == 25
+
+
+def test_seed_signal_count_sets_absolute_value(tmp_path):
+    path = str(tmp_path / "budget.json")
+    tb.bump_signal_count(20, path)
+    tb.seed_signal_count(1334, path)                       # reconcile against the Tesla portal
+    assert tb.usage_snapshot(path)["streaming"]["count"] == 1334
+    tb.bump_signal_count(6, path)                           # guard keeps counting from baseline
+    assert tb.usage_snapshot(path)["streaming"]["count"] == 1340
+
+
+def test_signal_count_never_affects_gated_total_or_remaining(tmp_path):
+    path = str(tmp_path / "budget.json")
+    tb.seed_month_usage({"command": 10, "data": 10, "wake": 1}, path)
+    before = tb.usage_snapshot(path)
+    tb.seed_signal_count(50000, path)                       # a lot of signals, still ~free
+    after = tb.usage_snapshot(path)
+    assert after["total"] == before["total"]
+    assert after["remaining"] == before["remaining"]
+    assert after["streaming"]["count"] == 50000
+    assert after["streaming"]["cost"] == round(50000 * tb.STREAMING_SIGNAL_COST_USD, 4)
+
+
+def test_seeding_one_category_does_not_wipe_the_others(tmp_path):
+    # Regression: seed_month_usage used to REPLACE the whole month_counts dict, so seeding just
+    # one category -- or seeding signals via the separate seed_signal_count call -- would
+    # silently wipe out whatever else was already recorded there.
+    path = str(tmp_path / "budget.json")
+    tb.seed_month_usage({"command": 13, "data": 30, "wake": 2}, path)
+    tb.seed_signal_count(1334, path)
+
+    tb.seed_month_usage({"wake": 5}, path)                  # only reconcile wake this time
+
+    snap = tb.usage_snapshot(path)
+    assert snap["categories"]["wake"]["count"] == 5         # updated
+    assert snap["categories"]["command"]["count"] == 13     # untouched
+    assert snap["categories"]["data"]["count"] == 30        # untouched
+    assert snap["streaming"]["count"] == 1334               # untouched by either seed call
+
+
+def test_signal_count_rolls_over_at_month_boundary(tmp_path):
+    import json as _json
+    path = str(tmp_path / "budget.json")
+    d = {"month": "2026-06", "date": "2026-06-30", "counts": {}, "month_counts": {"signals": 999}}
+    with open(path, "w") as f:
+        _json.dump(d, f)
+    # bump_signal_count/seed_signal_count use the real UTC clock (no injectable clock, unlike
+    # TeslaBudget) -- so this only proves the roll logic fires when the stored month differs
+    # from "now"; it can't pin an exact expected month without being a tautology of today's date.
+    new_total = tb.bump_signal_count(10, path)
+    assert new_total == 10                                  # rolled, not 1009
+
+
+def test_concurrent_spend_and_signal_bump_do_not_lose_updates(tmp_path):
+    # Regression: TeslaBudget.spend()/refund() and the module-level seed_month_usage()/
+    # bump_signal_count()/seed_signal_count() read-modify-write the SAME file. In production,
+    # the telemetry bridge's own MQTT thread calls bump_signal_count() every ~20 messages while
+    # the EV controller's timer thread concurrently calls spend() through the shared budget
+    # singleton -- without a lock shared between both call paths, one thread's read-modify-write
+    # can silently revert the other's update (the write itself is atomic, so this is a lost
+    # update, not file corruption).
+    import threading
+
+    path = str(tmp_path / "budget.json")
+    budget = tb.TeslaBudget(caps={"command": 0, "data": 10000, "wake": 0}, state_path=path)
+    n_spends, n_bumps = 200, 200
+
+    def spend_worker():
+        for _ in range(n_spends):
+            assert budget.spend("data") is True
+
+    def bump_worker():
+        for _ in range(n_bumps):
+            tb.bump_signal_count(1, path)
+
+    t1 = threading.Thread(target=spend_worker)
+    t2 = threading.Thread(target=bump_worker)
+    t1.start(); t2.start()
+    t1.join(); t2.join()
+
+    snap = tb.usage_snapshot(path)
+    assert snap["categories"]["data"]["count"] == n_spends
+    assert snap["streaming"]["count"] == n_bumps

--- a/tests/test_tesla_telemetry_bridge.py
+++ b/tests/test_tesla_telemetry_bridge.py
@@ -96,25 +96,23 @@ def test_on_message_counts_only_real_signals(monkeypatch):
     assert counted["n"] == 1                              # real vehicle-data signal counted
 
 
-def test_stream_signal_counter_batches_to_state(monkeypatch):
-    writes = {}
+def test_stream_signal_counter_batches_to_durable_file(tmp_path, monkeypatch):
+    # Durable (tesla_budget state file), not GlobalState (SQLite on tmpfs, wiped every restart
+    # by main.py's GlobalStateDatabase.__init__) -- a pod restart must not lose this count.
+    from lib import tesla_budget as budget_mod
 
-    class FakeState:
-        def get(self, k):
-            return writes.get(k)
-
-        def set(self, k, v):
-            writes[k] = v
-
-    import lib.global_state as gs
-    monkeypatch.setattr(gs, "GlobalStateClient", lambda *a, **k: FakeState())
+    path = str(tmp_path / "budget.json")
+    monkeypatch.setattr("lib.config_retrieval.retrieve_setting", lambda k: path)
 
     b = tb.TeslaTelemetryBridge("broker")
     for _ in range(tb._STREAM_FLUSH_EVERY - 1):
         b._count_stream_signal()
-    assert "tesla_stream_signals" not in writes          # below threshold -> no write yet
-    b._count_stream_signal()                              # hits threshold -> flush
-    assert writes["tesla_stream_signals"] == tb._STREAM_FLUSH_EVERY
+    assert budget_mod.usage_snapshot(path)["streaming"]["count"] == 0   # below threshold -> no write yet
+    b._count_stream_signal()                                            # hits threshold -> flush
+    assert budget_mod.usage_snapshot(path)["streaming"]["count"] == tb._STREAM_FLUSH_EVERY
+
+    # Surviving a "restart" just means re-reading the same file -- nothing in-memory to lose.
+    assert budget_mod.usage_snapshot(path)["streaming"]["count"] == tb._STREAM_FLUSH_EVERY
 
 
 def test_unknown_field_is_ignored():


### PR DESCRIPTION
## Summary

A user inspecting `data/tesla_budget.json` in production noticed it durably tracks command/data/wake spend (on a k8s hostPath-mounted volume, surviving pod restarts) but has no entry for Fleet Telemetry's "Streaming Signals" — and that the signal count resets to 0 on every restart.

**Root cause**: signal counting lived entirely in `lib.global_state.GlobalStateClient`, backed by a SQLite file on `/dev/shm` (tmpfs) — which `main.py`'s `GlobalStateDatabase.__init__()` explicitly `DROP TABLE IF EXISTS`s and recreates on every process start. So the count was silently wiped every restart and never touched the durable file at all.

## Fix

Moved signal tracking into the same durable `tesla_budget.json` file, as a `"signals"` key inside its existing `month_counts` dict:

- `lib/tesla_budget.py`: new `bump_signal_count()` (additive, called by the telemetry bridge as signals arrive) and `seed_signal_count()` (sets an absolute value, for one-time reconciliation against Tesla's billing portal — mirrors the existing `seed_month_usage()` for command/data/wake). `usage_snapshot()` now includes a `"streaming"` key, kept OUT of `total`/`remaining` since signals aren't gated by the spend guard (unchanged design intent, just relocated to a durable home).
- `lib/tesla_telemetry_bridge.py`: `_count_stream_signal()` now writes through `bump_signal_count()` instead of `GlobalStateClient`.
- `frontend/data.py`: `tesla_usage()` simplified — streaming is now included natively in `usage_snapshot()`, so the ~10 lines of GlobalState fallback logic are gone.
- `scripts/tesla_seed_usage.py`: added `--signals N` for one-time reconciliation against the Tesla developer portal's Billing & Usage page.

## Two bugs found and fixed along the way

**`seed_month_usage()` used to wholesale-replace `month_counts`.** It unconditionally rebuilt the dict from only the 3 known categories, so seeding one category (or the new signals count, which now lives in the same dict) would silently wipe out whatever else was there. Fixed to merge only the given keys. `scripts/tesla_seed_usage.py` updated to match — it only touches categories you actually pass (previously running it with e.g. only `--wakes 2` would have zeroed `--commands`/`--data` to 0, since they defaulted to 0 and got wholesale-replaced).

**A second-agent review caught a real, severe concurrency bug** in the first version of this fix: the new free functions (`bump_signal_count`/`seed_signal_count`/`seed_month_usage`) had no locking at all, while `TeslaBudget.spend()`/`refund()` use a private per-instance lock — two *different* synchronization domains protecting the *same file*. In production (`TESLA_TELEMETRY_ENABLED=True`), the telemetry bridge's own MQTT thread calls `bump_signal_count()` every ~20 messages while the EV controller's timer thread concurrently calls `spend()`/`refund()` through the shared budget singleton — a real, continuously-running race, not a theoretical one.

Reproduced it directly to confirm severity before trusting the finding: with locking disabled, 10/10 trials of 200 concurrent spends + 200 concurrent signal bumps lost updates — as low as 0 of 200 recorded in the worst case. Fixed with a process-wide, path-keyed `threading.RLock` shared by both `TeslaBudget` instances and the free functions. Verified 0/5 trials lose anything with the fix in place, and added `test_concurrent_spend_and_signal_bump_do_not_lose_updates` as a permanent regression test.

## Seeding your production count

Once this deploys, run once against your production budget state file (mounted at `/app/data/tesla_budget.json` per the k8s manifest) to reconcile with the number shown on Tesla's developer portal:

```bash
python scripts/tesla_seed_usage.py --signals 1334
```

This only touches the signals count — command/data/wake are left exactly as they are.

## Test plan

- [x] `DEV=1 pytest -q` — 295 passed
- [x] Visually verified (mock harness, never touches the real MQTT broker): Vehicle tab's "Tesla API usage" card correctly shows a seeded streaming-signal count, correctly excluded from "Total this month"
- [x] Independent second-agent review: found the concurrency bug above (now fixed), confirmed no other caller of `seed_month_usage()` relied on the old wipe-everything semantics, confirmed the month-rollover logic matches `TeslaBudget`'s existing rollover semantics
- [x] Reproduced the concurrency bug directly (10/10 lossy trials without the fix) and confirmed the fix resolves it (0/5 with it) before trusting the review finding